### PR TITLE
Extend result feed to 7 days, remove stray table tag and debug printing

### DIFF
--- a/lib/src/group_changes.dart
+++ b/lib/src/group_changes.dart
@@ -10,8 +10,6 @@ import 'dart:collection';
 import 'dart:convert';
 import 'dart:io';
 
-import 'package:resource/resource.dart' show Resource;
-
 import 'package:dart_ci/src/fetch_changes.dart';
 
 class MinMax {
@@ -425,15 +423,4 @@ String htmlPage(List<SummaryData> data, List<String> hashes,
   }
   page.write(postlude());
   return page.toString();
-}
-
-Future<List<String>> loadLines(Resource resource) => resource
-    .openRead()
-    .transform(utf8.decoder)
-    .transform(LineSplitter())
-    .toList();
-
-Future<Object> loadJson(Resource resource) async {
-  final json = await resource.openRead().transform(utf8.decoder).join();
-  return jsonDecode(json);
 }

--- a/lib/src/group_changes.dart
+++ b/lib/src/group_changes.dart
@@ -322,7 +322,6 @@ String htmlPage(List<SummaryData> data, List<String> hashes,
   }
 
   StringBuffer page = StringBuffer(prelude());
-  page.write("<table>");
 
   int commit = 0;
   for (final blamelistEndList in groups) {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,4 +11,3 @@ dependencies:
   googleapis: ^0.51.0
   googleapis_auth: ^0.2.7
   http: ^0.11.1+1
-  resource: ^2.1.5


### PR DESCRIPTION
This removes some debug printing added by the last commit, removes an unmatched table tag from the results feed, and extends the results feed to 7 days.