### PR TITLE
add github actions for all non-ui packages

### DIFF
--- a/.github/workflows/appengine.yaml
+++ b/.github/workflows/appengine.yaml
@@ -41,4 +41,7 @@ jobs:
 
       - run: dart format --output=none --set-exit-if-changed .
 
-      - run: dart test
+      # TODO: Tests should use `dart test`
+      # TODO: How to run this test?
+      # - run: dart test/create_source_test.dart
+      - run: dart test/test_source_test.dart

--- a/.github/workflows/appengine.yaml
+++ b/.github/workflows/appengine.yaml
@@ -1,0 +1,44 @@
+name: package:appengine
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/appengine.yaml'
+      - 'appengine/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/appengine.yaml'
+      - 'appengine/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: appengine
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 2.19.6
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+
+      - run: dart test

--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -41,4 +41,5 @@ jobs:
 
       - run: dart format --output=none --set-exit-if-changed .
 
-      - run: dart test
+      # TODO: Install gsutil and un-skip tests that require it
+      - run: dart test -x requires_gsutil

--- a/.github/workflows/baseline.yaml
+++ b/.github/workflows/baseline.yaml
@@ -1,0 +1,44 @@
+name: package:baseline
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/baseline.yaml'
+      - 'baseline/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/baseline.yaml'
+      - 'baseline/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: baseline
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 2.19.6
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+
+      - run: dart test

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -41,4 +41,5 @@ jobs:
 
       - run: dart format --output=none --set-exit-if-changed .
 
-      - run: dart test
+      # Skip the tests that require auth, at least for now.
+      - run: dart test -x requires_auth

--- a/.github/workflows/builder.yaml
+++ b/.github/workflows/builder.yaml
@@ -1,0 +1,44 @@
+name: package:builder
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/builder.yaml'
+      - 'builder/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/builder.yaml'
+      - 'builder/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: builder
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 3.1.0
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+
+      - run: dart test

--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -1,23 +1,23 @@
-name: package:builder
+name: package:current_results
 permissions: read-all
 
 on:
   # Run CI on all PRs (against any branch) and on pushes to the main branch.
   pull_request:
     paths:
-      - '.github/workflows/builder.yaml'
-      - 'builder/**'
+      - '.github/workflows/current_results.yaml'
+      - 'current_results/**'
   push:
     branches: [ main ]
     paths:
-      - '.github/workflows/builder.yaml'
-      - 'builder/**'
+      - '.github/workflows/current_results.yaml'
+      - 'current_results/**'
   schedule:
     - cron: '0 0 * * 0' # weekly
 
 defaults:
   run:
-    working-directory: builder
+    working-directory: current_results
 
 jobs:
   build:

--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -38,9 +38,11 @@ jobs:
 
       - run: dart pub get
 
-      - run: dart analyze --fatal-infos
+      # TODO: Enable once we get proto generation working
+      # - run: dart analyze --fatal-infos
 
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'stable' }}
 
-      - run: dart test
+      # TODO: Enable once we get proto generation working
+      # - run: dart test

--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -1,0 +1,46 @@
+name: package:builder
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/builder.yaml'
+      - 'builder/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/builder.yaml'
+      - 'builder/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: builder
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 3.7.0 # min pubspec SDK
+          - stable
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'stable' }}
+
+      - run: dart test

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -1,0 +1,46 @@
+name: package:functions
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/functions.yaml'
+      - 'github-label-notifier/functions/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/functions.yaml'
+      - 'github-label-notifier/functions/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: github-label-notifier/functions
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 2.18.0 # min pubspec SDK
+          - stable
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'stable' }}
+
+      - run: dart test

--- a/.github/workflows/functions.yaml
+++ b/.github/workflows/functions.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - 2.18.0 # min pubspec SDK
+          - 2.19.0 # min pubspec SDK
           - stable
         os:
           - ubuntu-latest
@@ -43,4 +43,5 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'stable' }}
 
-      - run: dart test
+      # TODO: Get these running, need to install firebase
+      # - run: test.sh

--- a/.github/workflows/symbolizer.yaml
+++ b/.github/workflows/symbolizer.yaml
@@ -1,0 +1,46 @@
+name: package:symbolizer
+permissions: read-all
+
+on:
+  # Run CI on all PRs (against any branch) and on pushes to the main branch.
+  pull_request:
+    paths:
+      - '.github/workflows/symbolizer.yaml'
+      - 'github-label-notifier/symbolizer/**'
+  push:
+    branches: [ main ]
+    paths:
+      - '.github/workflows/symbolizer.yaml'
+      - 'github-label-notifier/symbolizer/**'
+  schedule:
+    - cron: '0 0 * * 0' # weekly
+
+defaults:
+  run:
+    working-directory: github-label-notifier/symbolizer
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        sdk:
+          - 3.0.0 # min pubspec SDK
+          - stable
+        os:
+          - ubuntu-latest
+    steps:
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683
+      - uses: dart-lang/setup-dart@e51d8e571e22473a2ddebf0ef8a2123f0ab2c02c
+        with:
+          sdk: ${{ matrix.sdk }}
+
+      - run: dart pub get
+
+      - run: dart analyze --fatal-infos
+
+      - run: dart format --output=none --set-exit-if-changed .
+        if: ${{ matrix.sdk == 'stable' }}
+
+      - run: dart test

--- a/.github/workflows/symbolizer.yaml
+++ b/.github/workflows/symbolizer.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - 3.0.0 # min pubspec SDK
+          - 3.3.0 # min pubspec SDK
           - stable
         os:
           - ubuntu-latest
@@ -43,4 +43,5 @@ jobs:
       - run: dart format --output=none --set-exit-if-changed .
         if: ${{ matrix.sdk == 'stable' }}
 
-      - run: dart test
+      # TODO: Get these running, needs some LLVM related tools installed
+      # - run: dart test

--- a/baseline/dart_test.yaml
+++ b/baseline/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  requires_gsutil: {}

--- a/baseline/test/baseline_test.dart
+++ b/baseline/test/baseline_test.dart
@@ -76,7 +76,7 @@ main() {
       '--dry-run',
       '--ignore-unmapped',
     ], testData);
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline ignored config mapping', () async {
     final newBuilderStableResults = [
@@ -101,7 +101,7 @@ main() {
           newBuilderStableResults,
       ...testData,
     });
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline default config mapping', () async {
     final newBuilderDevResults = [
@@ -145,7 +145,7 @@ main() {
       'configuration/dev/config3/0/results.json': [newBuilderDevResults[2]],
       'configuration/dev/config4/0/results.json': [newBuilderDevResults[3]],
     });
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline dry-run', () async {
     await baselineTest([
@@ -156,7 +156,7 @@ main() {
           'config3:new-config3,config4:new-config4',
       '--dry-run',
     ], testData);
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline', () async {
     final newBuilderStableResults = [
@@ -202,7 +202,7 @@ main() {
       ],
       ...testData,
     });
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline with suite filter', () async {
     final newBuilderStableResults = [
@@ -236,7 +236,7 @@ main() {
       ],
       ...testData,
     });
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline merge configs', () async {
     final newBuilderStableResults = [
@@ -268,7 +268,7 @@ main() {
           newBuilderStableResults,
       ...testData,
     });
-  });
+  }, tags: ['requires_gsutil']);
 
   test('baseline split configs', () async {
     final newBuilderStableResults = [
@@ -301,7 +301,7 @@ main() {
       ],
       ...testData,
     });
-  });
+  }, tags: ['requires_gsutil']);
 }
 
 Future<void> baselineTest(

--- a/baseline/test/options_test.dart
+++ b/baseline/test/options_test.dart
@@ -79,7 +79,7 @@ main() {
         ConfigurationMapping.strict('foo', {
           'foo': ['bar']
         }),
-        'bar');
+        ['bar']);
     expect(
         () => ConfigurationMapping.strict('oof', {
               'foo': ['bar']
@@ -92,7 +92,7 @@ main() {
         ConfigurationMapping.relaxed('foo', {
           'foo': ['bar']
         }),
-        'bar');
+        ['bar']);
     expect(
         ConfigurationMapping.relaxed('oof', {
           'foo': ['bar']
@@ -105,11 +105,11 @@ main() {
         ConfigurationMapping.none('foo', {
           'foo': ['bar']
         }),
-        'foo');
+        ['foo']);
     expect(
         ConfigurationMapping.none('oof', {
           'foo': ['bar']
         }),
-        'oof');
+        ['oof']);
   });
 }

--- a/builder/dart_test.yaml
+++ b/builder/dart_test.yaml
@@ -1,0 +1,2 @@
+tags:
+  requires_auth: {}

--- a/builder/test/approvals_test.dart
+++ b/builder/test/approvals_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['requires_auth'])
+library;
+
 import 'package:builder/src/builder.dart';
 import 'package:builder/src/commits_cache.dart';
 import 'package:builder/src/firestore.dart';

--- a/builder/test/builder_test.dart
+++ b/builder/test/builder_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['requires_auth'])
+library;
+
 import 'package:builder/src/builder.dart';
 import 'package:builder/src/commits_cache.dart';
 import 'package:builder/src/firestore.dart';

--- a/builder/test/commits_cache_test.dart
+++ b/builder/test/commits_cache_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['requires_auth'])
+library;
+
 import 'package:googleapis/firestore/v1.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:http/http.dart' as http;

--- a/builder/test/firestore_test.dart
+++ b/builder/test/firestore_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['requires_auth'])
+library;
+
 import 'package:builder/src/firestore.dart';
 import 'package:test/test.dart';
 import 'package:googleapis_auth/auth_io.dart';

--- a/builder/test/tryjob_test.dart
+++ b/builder/test/tryjob_test.dart
@@ -2,6 +2,9 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
+@Tags(['requires_auth'])
+library;
+
 import 'package:builder/src/commits_cache.dart';
 import 'package:builder/src/firestore.dart';
 import 'package:builder/src/result.dart';

--- a/github-label-notifier/functions/pubspec.yaml
+++ b/github-label-notifier/functions/pubspec.yaml
@@ -6,7 +6,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=2.18.0 <4.0.0'
+  sdk: '>=2.19.0 <4.0.0'
 
 dependencies:
   async: ^2.10.0

--- a/github-label-notifier/functions/test/integration_test.dart
+++ b/github-label-notifier/functions/test/integration_test.dart
@@ -58,11 +58,10 @@ void main() async {
     throw 'This test must run in an emulated environment via test.sh script';
   }
 
-  // Mock SendGrid server which simply records all requests it recieves.
+  // Mock SendGrid server which simply records all requests it receives.
   late HttpServer sendgridMockServer;
   final sendgridRequests = <SendgridRequest>[];
 
-  late HttpServer symbolizerServer;
   final symbolizerCommands = <String>[];
 
   late int notifierPort;
@@ -211,35 +210,6 @@ void main() async {
             'login': 'hest',
             'html_url': 'https://github.com/hest',
           },
-        },
-        'repository': {
-          'full_name': 'dart-lang/webhook-test',
-        },
-      };
-
-  Map<String, dynamic> makeIssueCommentEvent(
-          {int number = 1,
-          String repositoryName = 'dart-lang/webhook-test',
-          String issueBody =
-              'This is an amazing ../third_party/dart/runtime/vm solution',
-          String commentBody = 'comment body goes here',
-          String authorAssociation = 'NONE'}) =>
-      {
-        'action': 'created',
-        'issue': {
-          'html_url':
-              'https://github.com/dart-lang/webhook-test/issues/$number',
-          'number': number,
-          'title': 'TEST ISSUE TITLE',
-          'body': issueBody,
-          'user': {
-            'login': 'hest',
-            'html_url': 'https://github.com/hest',
-          },
-        },
-        'comment': {
-          'body': commentBody,
-          'author_association': authorAssociation,
         },
         'repository': {
           'full_name': 'dart-lang/webhook-test',

--- a/github-label-notifier/symbolizer/bin/symbolize.dart
+++ b/github-label-notifier/symbolizer/bin/symbolize.dart
@@ -7,6 +7,7 @@
 ///
 ///    symbolize <input-file>|<github-uri> [overrides]
 ///
+library;
 
 import 'dart:io';
 

--- a/github-label-notifier/symbolizer/lib/model.dart
+++ b/github-label-notifier/symbolizer/lib/model.dart
@@ -155,12 +155,10 @@ const noteMessage = <SymbolizationNoteKind, String>{
 
 @freezed
 class SymbolizationResult with _$SymbolizationResult {
-  @JsonSerializable(explicitToJson: true)
   factory SymbolizationResult.ok({
     required List<CrashSymbolizationResult> results,
   }) = SymbolizationResultOk;
 
-  @JsonSerializable(explicitToJson: true)
   factory SymbolizationResult.error({
     required SymbolizationNote error,
   }) = SymbolizationResultError;
@@ -172,7 +170,6 @@ class SymbolizationResult with _$SymbolizationResult {
 /// Result of symbolizing an engine crash.
 @freezed
 class CrashSymbolizationResult with _$CrashSymbolizationResult {
-  @JsonSerializable(explicitToJson: true)
   factory CrashSymbolizationResult({
     required Crash crash,
     required EngineBuild? engineBuild,

--- a/github-label-notifier/symbolizer/lib/symbolizer.dart
+++ b/github-label-notifier/symbolizer/lib/symbolizer.dart
@@ -93,7 +93,7 @@ class Symbolizer {
     }
     if (engineHash != null) {
       // Try to expand short hash into full hash.
-      var engineCommit;
+      RepositoryCommit engineCommit;
       try {
         engineCommit = await github.repositories
             .getCommit(RepositorySlug('flutter', 'flutter'), engineHash);

--- a/github-label-notifier/symbolizer/lib/symbols.dart
+++ b/github-label-notifier/symbolizer/lib/symbols.dart
@@ -179,7 +179,7 @@ class SymbolsCache {
 
     // Download symbols into a temporary directory, once we successfully
     // unpack them we will rename this directory.
-    final tempDir = Directory(dir.path + "-temp");
+    final tempDir = Directory('${dir.path}-temp');
     tempDir.createSync();
     try {
       await downloader(tempDir, build);

--- a/github-label-notifier/symbolizer/pubspec.yaml
+++ b/github-label-notifier/symbolizer/pubspec.yaml
@@ -7,7 +7,7 @@ version: 0.0.1
 publish_to: none
 
 environment:
-  sdk: '>=3.0.0 <4.0.0'
+  sdk: '>=3.3.0 <4.0.0'
 
 executables:
   symbolize:


### PR DESCRIPTION
I can follow up with some of the more complicated UI packages (flutter/angular apps).

I also had to skip many sets of tests for now just due to missing dependencies and such, I filed https://github.com/dart-lang/dart_ci/issues/173 to follow up on these. But, some testing is better than no testing for now.

**EDIT**: UI packages PR is here https://github.com/dart-lang/dart_ci/pull/174