### PR TITLE
Extract an abstract base class for QueryResults

### DIFF
--- a/current_results_ui/lib/filter.dart
+++ b/current_results_ui/lib/filter.dart
@@ -52,7 +52,7 @@ class _FilterUIState extends State<FilterUI> {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<QueryResults>(
+    return Consumer<QueryResultsBase>(
       builder: (context, results, child) {
         final filter = results.filter;
         return Column(

--- a/current_results_ui/lib/main.dart
+++ b/current_results_ui/lib/main.dart
@@ -88,7 +88,9 @@ class AppProviders extends StatelessWidget {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<AuthService>(create: (_) => AuthService()),
-        ChangeNotifierProvider<QueryResults>(create: (_) => QueryResults()),
+        ChangeNotifierProvider<QueryResultsBase>(
+          create: (_) => QueryResults(Filter('')),
+        ),
       ],
       child: child,
     );
@@ -115,7 +117,8 @@ class _CurrentResultsScreenState extends State<CurrentResultsScreen>
   @override
   void initState() {
     super.initState();
-    Provider.of<QueryResults>(context, listen: false).fetch(widget.filter);
+    Provider.of<QueryResultsBase>(context, listen: false).filter =
+        widget.filter;
     _tabController = TabController(
       initialIndex: widget.initialTabIndex,
       length: 3,
@@ -127,7 +130,8 @@ class _CurrentResultsScreenState extends State<CurrentResultsScreen>
   void didUpdateWidget(CurrentResultsScreen oldWidget) {
     super.didUpdateWidget(oldWidget);
     if (widget.filter != oldWidget.filter) {
-      Provider.of<QueryResults>(context, listen: false).fetch(widget.filter);
+      Provider.of<QueryResultsBase>(context, listen: false).filter =
+          widget.filter;
     }
     _tabController.index = widget.initialTabIndex;
   }
@@ -229,7 +233,7 @@ class JsonLink extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<QueryResults>(
+    return Consumer<QueryResultsBase>(
       builder: (context, results, child) {
         return TextButton(
           child: const Text('JSON'),
@@ -250,8 +254,8 @@ class TextPopup extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Consumer<QueryResults>(
-      builder: (context, QueryResults results, child) {
+    return Consumer<QueryResultsBase>(
+      builder: (context, QueryResultsBase results, child) {
         return Tooltip(
           message: 'Results query as text',
           waitDuration: const Duration(milliseconds: 500),

--- a/current_results_ui/test/query_test.dart
+++ b/current_results_ui/test/query_test.dart
@@ -1,0 +1,111 @@
+// Copyright (c) 2025, the Dart project authors. Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+
+import 'package:flutter_current_results/filter.dart';
+import 'package:flutter_current_results/results.dart';
+import 'package:flutter_current_results/src/generated/query.pb.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_current_results/query.dart';
+import 'package:http/http.dart' as http;
+import 'package:mockito/annotations.dart';
+import 'package:mockito/mockito.dart';
+
+import 'query_test.mocks.dart';
+
+@GenerateNiceMocks([MockSpec<http.Client>()])
+void main() {
+  group('ChangeInResult', () {
+    test('flaky result', () {
+      final result = Result(
+        result: 'RuntimeError',
+        expected: 'Pass',
+        flaky: true,
+      );
+      final change = ChangeInResult(result);
+      expect(change.kind, ResultKind.flaky);
+      expect(change.text, 'flaky (latest result RuntimeError expected Pass)');
+    });
+
+    test('matching result', () {
+      final result = Result(result: 'Pass', expected: 'Pass', flaky: false);
+      final change = ChangeInResult(result);
+      expect(change.kind, ResultKind.pass);
+      expect(change.text, 'Pass');
+    });
+
+    test('failing result', () {
+      final result = Result(
+        result: 'RuntimeError',
+        expected: 'Pass',
+        flaky: false,
+      );
+      final change = ChangeInResult(result);
+      expect(change.kind, ResultKind.fail);
+      expect(change.text, 'RuntimeError (expected Pass)');
+    });
+
+    test('comparison', () {
+      final pass = ChangeInResult(Result(result: 'Pass', expected: 'Pass'));
+      final fail = ChangeInResult(
+        Result(result: 'RuntimeError', expected: 'Pass'),
+      );
+      final flaky = ChangeInResult(
+        Result(result: 'RuntimeError', expected: 'Pass', flaky: true),
+      );
+
+      expect(pass.compareTo(fail), 1);
+      expect(fail.compareTo(pass), -1);
+      expect(flaky.compareTo(fail), -1);
+      expect(fail.compareTo(flaky), 1);
+      expect(pass.compareTo(flaky), 1);
+      expect(flaky.compareTo(pass), -1);
+    });
+
+    test('caching', () {
+      final result1 = Result(result: 'Pass', expected: 'Pass');
+      final result2 = Result(result: 'Pass', expected: 'Pass');
+      final change1 = ChangeInResult(result1);
+      final change2 = ChangeInResult(result2);
+      expect(identical(change1, change2), isTrue);
+    });
+  });
+
+  group('QueryResults', () {
+    late MockClient mockClient;
+    late QueryResults queryResults;
+
+    setUp(() {
+      mockClient = MockClient();
+      queryResults = QueryResults(Filter(''), client: mockClient);
+    });
+
+    test('fetches and processes results', () async {
+      final response = GetResultsResponse(
+        results: [
+          Result(name: 'test1', result: 'Pass', expected: 'Pass'),
+          Result(name: 'test2', result: 'Fail', expected: 'Pass'),
+        ],
+        nextPageToken: '',
+      );
+      when(mockClient.get(any)).thenAnswer(
+        (_) async => http.Response(jsonEncode(response.toProto3Json()), 200),
+      );
+
+      queryResults.filter = Filter('test');
+
+      await untilCalled(mockClient.get(any));
+      while (!queryResults.isDone) {
+        await Future.delayed(Duration.zero);
+      }
+
+      expect(queryResults.names, ['test1', 'test2']);
+      expect(queryResults.counts['test1']!.count, 1);
+      expect(queryResults.counts['test1']!.countPassing, 1);
+      expect(queryResults.counts['test2']!.count, 1);
+      expect(queryResults.counts['test2']!.countFailing, 1);
+    });
+  });
+}

--- a/current_results_ui/test/widget_test.dart
+++ b/current_results_ui/test/widget_test.dart
@@ -3,6 +3,7 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'package:flutter/material.dart';
+import 'package:flutter_current_results/filter.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/mockito.dart';
 import 'package:provider/provider.dart';
@@ -41,12 +42,12 @@ class MockAuthService extends Mock implements AuthService {
 
 void main() {
   late MockAuthService mockAuthService;
-  late QueryResults queryResults;
+  late QueryResultsBase queryResults;
   late TabController tabController;
 
   setUp(() {
     mockAuthService = MockAuthService();
-    queryResults = QueryResults();
+    queryResults = QueryResults(Filter(''));
     tabController = TabController(length: 3, vsync: const TestVSync());
   });
 
@@ -54,7 +55,7 @@ void main() {
     return MultiProvider(
       providers: [
         ChangeNotifierProvider<AuthService>.value(value: mockAuthService),
-        ChangeNotifierProvider<QueryResults>.value(value: queryResults),
+        ChangeNotifierProvider<QueryResultsBase>.value(value: queryResults),
         ChangeNotifierProvider<TabController>.value(value: tabController),
       ],
       child: MaterialApp(


### PR DESCRIPTION
This will be used to add a new implementation based on the results feed's firebase backend to support try results.