### PR TITLE
[current_results] Add a REST API

### DIFF
--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -26,7 +26,7 @@ jobs:
       fail-fast: false
       matrix:
         sdk:
-          - 3.10.0 # min pubspec SDK
+          - 3.11.0 # min pubspec SDK
           - stable
         os:
           - ubuntu-latest

--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -46,10 +46,10 @@ jobs:
 
       - run: ./tools/generate_protogen.sh
 
-      - run: dart analyze --fatal-infos
-
       - name: Generate files
         run: dart pub run build_runner build --delete-conflicting-outputs
+
+      - run: dart analyze --fatal-infos
 
       # We don't want to format third_party/ but dart format doesn't support
       # excluding a directory.

--- a/.github/workflows/current_results.yaml
+++ b/.github/workflows/current_results.yaml
@@ -48,6 +48,9 @@ jobs:
 
       - run: dart analyze --fatal-infos
 
+      - name: Generate files
+        run: dart pub run build_runner build --delete-conflicting-outputs
+
       # We don't want to format third_party/ but dart format doesn't support
       # excluding a directory.
       - run: dart format --output=none --set-exit-if-changed lib/ bin/ endpoints/ test/ tools/

--- a/current_results/analysis_options.yaml
+++ b/current_results/analysis_options.yaml
@@ -2,3 +2,7 @@ include: package:lints/recommended.yaml
 analyzer:
   exclude:
     - third_party/
+
+linter:
+  rules:
+    - directives_ordering

--- a/current_results/bin/client.dart
+++ b/current_results/bin/client.dart
@@ -5,9 +5,8 @@
 import 'dart:convert';
 
 import 'package:args/command_runner.dart';
-import 'package:grpc/grpc.dart';
-
 import 'package:current_results/src/generated/query.pbgrpc.dart';
+import 'package:grpc/grpc.dart';
 
 void main(List<String> args) async {
   final runner =

--- a/current_results/bin/server.dart
+++ b/current_results/bin/server.dart
@@ -4,20 +4,18 @@
 
 import 'dart:io';
 
+import 'package:current_results/src/api_impl.dart';
+import 'package:current_results/src/bucket.dart';
+import 'package:current_results/src/logger.dart';
+import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/rest_api.dart';
+import 'package:current_results/src/slice.dart';
 import 'package:gcloud/storage.dart';
 import 'package:googleapis_auth/auth_io.dart';
 import 'package:grpc/grpc.dart';
-import 'package:pool/pool.dart';
-
 import 'package:logging/logging.dart';
-
-import 'package:current_results/src/api_impl.dart';
-import 'package:current_results/src/bucket.dart';
-import 'package:current_results/src/slice.dart';
-import 'package:current_results/src/notifications.dart';
-import 'package:current_results/src/logger.dart';
+import 'package:pool/pool.dart';
 import 'package:shelf/shelf_io.dart' as shelf_io;
-import 'package:current_results/src/rest_api.dart';
 
 final _log = Logger('server');
 

--- a/current_results/bin/server.dart
+++ b/current_results/bin/server.dart
@@ -16,6 +16,8 @@ import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/slice.dart';
 import 'package:current_results/src/notifications.dart';
 import 'package:current_results/src/logger.dart';
+import 'package:shelf/shelf_io.dart' as shelf_io;
+import 'package:current_results/src/rest_api.dart';
 
 final _log = Logger('server');
 
@@ -39,6 +41,14 @@ Future<void> startServer(int port, ResultsBucket bucket) async {
   );
   await grpcServer.serve(port: port);
   _log.info('Grpc serving on port ${grpcServer.port}');
+
+  final restApi = RestApi(current, notifications, bucket);
+  final shelfServer = await shelf_io.serve(
+    restApi.handleRequest,
+    '0.0.0.0',
+    port + 1,
+  );
+  _log.info('REST serving on port ${shelfServer.port}');
 }
 
 Future<Slice> loadData(ResultsBucket bucket) async {

--- a/current_results/lib/src/api_impl.dart
+++ b/current_results/lib/src/api_impl.dart
@@ -71,9 +71,7 @@ Future<FetchResponse> fetchUpdates(
   for (final configuration in configurations) {
     final lines = await bucket.latestResults(configuration);
     current.add(lines);
-    response.updates.add(
-      ConfigurationUpdate()..configuration = configuration,
-    );
+    response.updates.add(ConfigurationUpdate()..configuration = configuration);
   }
   current.dropResultsOlderThan(maximumAge);
   current.collectTestNames();

--- a/current_results/lib/src/api_impl.dart
+++ b/current_results/lib/src/api_impl.dart
@@ -45,30 +45,37 @@ class QueryService extends QueryServiceBase {
   }
 
   @override
-  Future<FetchResponse> fetch(ServiceCall call, Empty request) async {
-    final response = FetchResponse();
-    final messages = await notifications.getMessages();
-    final latestObjectPattern = RegExp('^(configuration/main/[^/]+/)latest\$');
-    final configurations = <String>{};
-    for (final message in messages) {
-      if (message.attributes['eventType'] == 'OBJECT_FINALIZE') {
-        final match = latestObjectPattern.firstMatch(
-          message.attributes['objectId']!,
-        );
-        if (match != null) {
-          configurations.add(match[1]!);
-        }
+  Future<FetchResponse> fetch(ServiceCall call, Empty request) =>
+      fetchUpdates(notifications, bucket, current);
+}
+
+Future<FetchResponse> fetchUpdates(
+  BucketNotifications notifications,
+  ResultsBucket bucket,
+  Slice current,
+) async {
+  final response = FetchResponse();
+  final messages = await notifications.getMessages();
+  final latestObjectPattern = RegExp('^(configuration/main/[^/]+/)latest\$');
+  final configurations = <String>{};
+  for (final message in messages) {
+    if (message.attributes['eventType'] == 'OBJECT_FINALIZE') {
+      final match = latestObjectPattern.firstMatch(
+        message.attributes['objectId']!,
+      );
+      if (match != null) {
+        configurations.add(match[1]!);
       }
     }
-    for (final configuration in configurations) {
-      final lines = await bucket.latestResults(configuration);
-      current.add(lines);
-      response.updates.add(
-        ConfigurationUpdate()..configuration = configuration,
-      );
-    }
-    current.dropResultsOlderThan(maximumAge);
-    current.collectTestNames();
-    return response;
   }
+  for (final configuration in configurations) {
+    final lines = await bucket.latestResults(configuration);
+    current.add(lines);
+    response.updates.add(
+      ConfigurationUpdate()..configuration = configuration,
+    );
+  }
+  current.dropResultsOlderThan(maximumAge);
+  current.collectTestNames();
+  return response;
 }

--- a/current_results/lib/src/api_impl.dart
+++ b/current_results/lib/src/api_impl.dart
@@ -2,12 +2,11 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:grpc/grpc.dart';
-
 import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/generated/query.pbgrpc.dart';
-import 'package:current_results/src/slice.dart';
 import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/slice.dart';
+import 'package:grpc/grpc.dart';
 
 class QueryService extends QueryServiceBase {
   Slice current;

--- a/current_results/lib/src/notifications.dart
+++ b/current_results/lib/src/notifications.dart
@@ -2,9 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:grpc/grpc.dart';
-
 import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart';
+import 'package:grpc/grpc.dart';
 
 class BucketNotifications {
   late SubscriberClient client;

--- a/current_results/lib/src/rest_api.dart
+++ b/current_results/lib/src/rest_api.dart
@@ -1,0 +1,66 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
+import 'dart:convert';
+import 'package:shelf/shelf.dart';
+import 'package:current_results/src/slice.dart';
+import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/bucket.dart';
+import 'package:current_results/src/generated/query.pb.dart' as api;
+import 'package:protobuf/protobuf.dart';
+import 'package:current_results/src/api_impl.dart' show fetchUpdates;
+
+class RestApi {
+  final Slice current;
+  final BucketNotifications notifications;
+  final ResultsBucket bucket;
+
+  RestApi(this.current, this.notifications, this.bucket);
+
+  Future<Response> handleRequest(Request request) async {
+    final path = request.url.path;
+    if (path == 'v1/results' && request.method == 'GET') {
+      return _getResults(request);
+    } else if (path == 'v1/tests' && request.method == 'GET') {
+      return _listTests(request);
+    } else if (path == 'v1/fetch' && request.method == 'POST') {
+      return _fetch(request);
+    } else if ((path == 'v1/testPaths' || path == 'v1/configurations') && request.method == 'GET') {
+      return Response(501, body: 'Unimplemented');
+    }
+    return Response.notFound('Not Found');
+  }
+
+  Future<Response> _getResults(Request request) async {
+    final params = request.url.queryParameters;
+    final protoRequest = api.GetResultsRequest();
+    if (params.containsKey('filter')) protoRequest.filter = params['filter']!;
+    if (params.containsKey('page_size')) {
+      protoRequest.pageSize = int.tryParse(params['page_size']!) ?? 0;
+    }
+    if (params.containsKey('page_token')) {
+      protoRequest.pageToken = params['page_token']!;
+    }
+    final response = current.results(protoRequest);
+    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+  }
+
+  Future<Response> _listTests(Request request) async {
+    final params = request.url.queryParameters;
+    final protoRequest = api.ListTestsRequest();
+    if (params.containsKey('prefix')) protoRequest.prefix = params['prefix']!;
+    if (params.containsKey('limit')) {
+      protoRequest.limit = int.tryParse(params['limit']!) ?? 0;
+    }
+    final response = current.listTests(protoRequest);
+    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+  }
+
+  Future<Response> _fetch(Request request) async {
+    final response = await fetchUpdates(notifications, bucket, current);
+    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+  }
+
+  String _toJson(GeneratedMessage message) => jsonEncode(message.toProto3Json());
+}

--- a/current_results/lib/src/rest_api.dart
+++ b/current_results/lib/src/rest_api.dart
@@ -38,12 +38,14 @@ class RestApi {
   Future<Response> _getResults(Request request) async {
     final params = request.url.queryParameters;
     final protoRequest = api.GetResultsRequest();
-    if (params.containsKey('filter')) protoRequest.filter = params['filter']!;
-    if (params.containsKey('page_size')) {
-      protoRequest.pageSize = int.tryParse(params['page_size']!) ?? 0;
+    if (params['filter'] case final filter?) {
+      protoRequest.filter = filter;
     }
-    if (params.containsKey('page_token')) {
-      protoRequest.pageToken = params['page_token']!;
+    if (params['page_size'] case final pageSize?) {
+      protoRequest.pageSize = int.tryParse(pageSize) ?? 0;
+    }
+    if (params['page_token'] case final pageToken?) {
+      protoRequest.pageToken = pageToken;
     }
     final response = current.results(protoRequest);
     return Response.ok(
@@ -56,9 +58,11 @@ class RestApi {
   Future<Response> _listTests(Request request) async {
     final params = request.url.queryParameters;
     final protoRequest = api.ListTestsRequest();
-    if (params.containsKey('prefix')) protoRequest.prefix = params['prefix']!;
-    if (params.containsKey('limit')) {
-      protoRequest.limit = int.tryParse(params['limit']!) ?? 0;
+    if (params['prefix'] case final prefix?) {
+      protoRequest.prefix = prefix;
+    }
+    if (params['limit'] case final limit?) {
+      protoRequest.limit = int.tryParse(limit) ?? 0;
     }
     final response = current.listTests(protoRequest);
     return Response.ok(

--- a/current_results/lib/src/rest_api.dart
+++ b/current_results/lib/src/rest_api.dart
@@ -3,13 +3,17 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'package:shelf/shelf.dart';
-import 'package:current_results/src/slice.dart';
-import 'package:current_results/src/notifications.dart';
+
+import 'package:current_results/src/api_impl.dart' show fetchUpdates;
 import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/generated/query.pb.dart' as api;
+import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/slice.dart';
 import 'package:protobuf/protobuf.dart';
-import 'package:current_results/src/api_impl.dart' show fetchUpdates;
+import 'package:shelf/shelf.dart';
+import 'package:shelf_router/shelf_router.dart';
+
+part 'rest_api.g.dart';
 
 class RestApi {
   final Slice current;
@@ -18,21 +22,19 @@ class RestApi {
 
   RestApi(this.current, this.notifications, this.bucket);
 
-  Future<Response> handleRequest(Request request) async {
-    final path = request.url.path;
-    if (path == 'v1/results' && request.method == 'GET') {
-      return _getResults(request);
-    } else if (path == 'v1/tests' && request.method == 'GET') {
-      return _listTests(request);
-    } else if (path == 'v1/fetch' && request.method == 'POST') {
-      return _fetch(request);
-    } else if ((path == 'v1/testPaths' || path == 'v1/configurations') &&
-        request.method == 'GET') {
-      return Response(501, body: 'Unimplemented');
-    }
-    return Response.notFound('Not Found');
-  }
+  Router get router => _$RestApiRouter(this);
 
+  Future<Response> handleRequest(Request request) => router(request);
+
+  @Route.get('/v1/testPaths')
+  Future<Response> _testPaths(Request request) async =>
+      Response(501, body: 'Unimplemented');
+
+  @Route.get('/v1/configurations')
+  Future<Response> _configurations(Request request) async =>
+      Response(501, body: 'Unimplemented');
+
+  @Route.get('/v1/results')
   Future<Response> _getResults(Request request) async {
     final params = request.url.queryParameters;
     final protoRequest = api.GetResultsRequest();
@@ -50,6 +52,7 @@ class RestApi {
     );
   }
 
+  @Route.get('/v1/tests')
   Future<Response> _listTests(Request request) async {
     final params = request.url.queryParameters;
     final protoRequest = api.ListTestsRequest();
@@ -64,6 +67,7 @@ class RestApi {
     );
   }
 
+  @Route.post('/v1/fetch')
   Future<Response> _fetch(Request request) async {
     final response = await fetchUpdates(notifications, bucket, current);
     return Response.ok(

--- a/current_results/lib/src/rest_api.dart
+++ b/current_results/lib/src/rest_api.dart
@@ -26,7 +26,8 @@ class RestApi {
       return _listTests(request);
     } else if (path == 'v1/fetch' && request.method == 'POST') {
       return _fetch(request);
-    } else if ((path == 'v1/testPaths' || path == 'v1/configurations') && request.method == 'GET') {
+    } else if ((path == 'v1/testPaths' || path == 'v1/configurations') &&
+        request.method == 'GET') {
       return Response(501, body: 'Unimplemented');
     }
     return Response.notFound('Not Found');
@@ -43,7 +44,10 @@ class RestApi {
       protoRequest.pageToken = params['page_token']!;
     }
     final response = current.results(protoRequest);
-    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+    return Response.ok(
+      _toJson(response),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
   Future<Response> _listTests(Request request) async {
@@ -54,13 +58,20 @@ class RestApi {
       protoRequest.limit = int.tryParse(params['limit']!) ?? 0;
     }
     final response = current.listTests(protoRequest);
-    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+    return Response.ok(
+      _toJson(response),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
   Future<Response> _fetch(Request request) async {
     final response = await fetchUpdates(notifications, bucket, current);
-    return Response.ok(_toJson(response), headers: {'Content-Type': 'application/json'});
+    return Response.ok(
+      _toJson(response),
+      headers: {'Content-Type': 'application/json'},
+    );
   }
 
-  String _toJson(GeneratedMessage message) => jsonEncode(message.toProto3Json());
+  String _toJson(GeneratedMessage message) =>
+      jsonEncode(message.toProto3Json());
 }

--- a/current_results/lib/src/slice.dart
+++ b/current_results/lib/src/slice.dart
@@ -6,12 +6,11 @@ import 'dart:convert';
 import 'dart:math';
 
 import 'package:collection/collection.dart';
-import 'package:logging/logging.dart';
-
-import 'package:current_results/src/result.dart';
 import 'package:current_results/src/generated/query.pb.dart' as query_api;
 import 'package:current_results/src/generated/result.pb.dart' as api;
 import 'package:current_results/src/iterable.dart';
+import 'package:current_results/src/result.dart';
+import 'package:logging/logging.dart';
 
 const maximumAge = Duration(days: 7);
 

--- a/current_results/pubspec.lock
+++ b/current_results/pubspec.lock
@@ -13,18 +13,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "796d97d925add7ffcdf5595f33a2066a6e3cee97971e6dbef09b76b7880fd760"
+      sha256: "3b19a47f6ea7c2632760777c78174f47f6aec1e05f0cd611380d4593b8af1dbc"
       url: "https://pub.dev"
     source: hosted
-    version: "94.0.0"
+    version: "96.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "9c8ebb304d72c0a0c8764344627529d9503fc83d7d73e43ed727dc532f822e4b"
+      sha256: "0c516bc4ad36a1a75759e54d5047cb9d15cded4459df01aa35a0b5ec7db2c2a0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.2"
+    version: "10.2.0"
   args:
     dependency: "direct main"
     description:
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: dart_style
-      sha256: "15a7db352c8fc6a4d2bc475ba901c25b39fe7157541da4c16eacce6f8be83e49"
+      sha256: "29f7ecc274a86d32920b1d9cfc7502fa87220da41ec60b55f329559d5732e2b2"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.5"
+    version: "3.1.7"
   file:
     dependency: transitive
     description:
@@ -209,6 +209,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: "76a1552170210c8a51500d555e93b526f92ab2a86aadbebd8b8d5f3d83a97c29"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.0"
   google_identity_services_web:
     dependency: transitive
     description:
@@ -229,10 +237,10 @@ packages:
     dependency: "direct main"
     description:
       name: googleapis_auth
-      sha256: b81fe352cc4a330b3710d2b7ad258d9bcef6f909bb759b306bf42973a7d046db
+      sha256: "2e8edbfff4fc0f0c99c9ff72353d72c355a96b8686de4b26f63c86e22696d7b9"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.2.0"
   graphs:
     dependency: transitive
     description:
@@ -317,10 +325,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
+      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.18"
+    version: "0.12.19"
   meta:
     dependency: transitive
     description:
@@ -525,26 +533,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "54c516bbb7cee2754d327ad4fca637f78abfc3cbcc5ace83b3eda117e42cd71a"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.29.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.9"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "394f07d21f0f2255ec9e3989f21e54d3c7dc0e6e9dbce160e5a9c1a6be0e2943"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.15"
+    version: "0.6.16"
   typed_data:
     dependency: transitive
     description:
@@ -610,4 +618,4 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.10.0 <4.0.0"
+  dart: ">=3.11.0 <4.0.0"

--- a/current_results/pubspec.lock
+++ b/current_results/pubspec.lock
@@ -49,6 +49,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
+  build:
+    dependency: transitive
+    description:
+      name: build
+      sha256: "275bf6bb2a00a9852c28d4e0b410da1d833a734d57d39d44f94bfc895a484ec3"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.4"
+  build_config:
+    dependency: transitive
+    description:
+      name: build_config
+      sha256: "4070d2a59f8eec34c97c86ceb44403834899075f66e8a9d59706f8e7834f6f71"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.3.0"
+  build_daemon:
+    dependency: transitive
+    description:
+      name: build_daemon
+      sha256: bf05f6e12cfea92d3c09308d7bcdab1906cd8a179b023269eed00c071004b957
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.1"
+  build_runner:
+    dependency: "direct dev"
+    description:
+      name: build_runner
+      sha256: "7981eb922842c77033026eb4341d5af651562008cdb116bdfa31fc46516b6462"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.12.2"
+  built_collection:
+    dependency: transitive
+    description:
+      name: built_collection
+      sha256: "376e3dd27b51ea877c28d525560790aee2e6fbb5f20e2f85d5081027d94e2100"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.1.1"
+  built_value:
+    dependency: transitive
+    description:
+      name: built_value
+      sha256: "6ae8a6435a8c6520c7077b107e77f1fb4ba7009633259a4d49a8afd8e7efc5e9"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.12.4"
+  checked_yaml:
+    dependency: transitive
+    description:
+      name: checked_yaml
+      sha256: "959525d3162f249993882720d52b7e0c833978df229be20702b33d48d91de70f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.4"
   cli_config:
     dependency: transitive
     description:
@@ -65,6 +121,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.1.2"
+  code_builder:
+    dependency: transitive
+    description:
+      name: code_builder
+      sha256: "6a6cab2ba4680d6423f34a9b972a4c9a94ebe1b62ecec4e1a1f2cba91fd1319d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.1"
   collection:
     dependency: "direct main"
     description:
@@ -169,6 +233,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  graphs:
+    dependency: transitive
+    description:
+      name: graphs
+      sha256: "741bbf84165310a68ff28fe9e727332eef1407342fca52759cb21ad8177bb8d0"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.2"
   grpc:
     dependency: "direct main"
     description:
@@ -217,6 +289,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.5"
+  json_annotation:
+    dependency: transitive
+    description:
+      name: json_annotation
+      sha256: cb09e7dac6210041fad964ed7fbee004f14258b4eca4040f72d1234062ace4c8
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.11.0"
   lints:
     dependency: "direct dev"
     description:
@@ -257,6 +337,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mockito:
+    dependency: "direct dev"
+    description:
+      name: mockito
+      sha256: a45d1aa065b796922db7b9e7e7e45f921aed17adf3a8318a1f47097e7e695566
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.6.3"
   node_preamble:
     dependency: transitive
     description:
@@ -313,6 +401,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
+  pubspec_parse:
+    dependency: transitive
+    description:
+      name: pubspec_parse
+      sha256: "0560ba233314abbed0a48a2956f7f022cce7c3e1e73df540277da7544cad4082"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.5.0"
   retry:
     dependency: transitive
     description:
@@ -353,6 +449,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  source_gen:
+    dependency: transitive
+    description:
+      name: source_gen
+      sha256: "1d562a3c1f713904ebbed50d2760217fd8a51ca170ac4b05b0db490699dbac17"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.0"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -393,6 +497,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      sha256: ad47125e588cfd37a9a7f86c7d6356dde8dfe89d071d293f80ca9e9273a33871
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:

--- a/current_results/pubspec.lock
+++ b/current_results/pubspec.lock
@@ -273,6 +273,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.1"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -441,6 +449,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.2"
+  shelf_router:
+    dependency: "direct main"
+    description:
+      name: shelf_router
+      sha256: f5e5d492440a7fb165fe1e2e1a623f31f734d3370900070b2b1e0d0428d59864
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
+  shelf_router_generator:
+    dependency: "direct dev"
+    description:
+      name: shelf_router_generator
+      sha256: "50e7e65a2da6c74bf4d06b99ae591c9c6f8e9109797227fe7d449d0927d023ac"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.4"
   shelf_static:
     dependency: transitive
     description:

--- a/current_results/pubspec.yaml
+++ b/current_results/pubspec.yaml
@@ -3,7 +3,7 @@ description: Cache and serve the most recent test results from Dart CI.
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 dependencies:
   args: ^2.4.2

--- a/current_results/pubspec.yaml
+++ b/current_results/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   pool: ^1.5.1
   protobuf: ^6.0.0
   shelf: ^1.4.0
+  shelf_router: ^1.1.4
   stack_trace: ^1.12.1
 
 dev_dependencies:
@@ -23,4 +24,5 @@ dev_dependencies:
   lints: ^6.0.0
   mockito: ^5.6.3
   protoc_plugin: ^25.0.0
+  shelf_router_generator: ^1.1.4
   test: ^1.25.0

--- a/current_results/pubspec.yaml
+++ b/current_results/pubspec.yaml
@@ -19,6 +19,8 @@ dependencies:
   stack_trace: ^1.12.1
 
 dev_dependencies:
+  build_runner: ^2.12.2
   lints: ^6.0.0
+  mockito: ^5.6.3
   protoc_plugin: ^25.0.0
   test: ^1.25.0

--- a/current_results/test/filter_test.dart
+++ b/current_results/test/filter_test.dart
@@ -5,11 +5,10 @@
 import 'dart:convert';
 
 import 'package:collection/collection.dart';
-import 'package:test/test.dart';
-
 import 'package:current_results/src/generated/query.pb.dart' as query_api;
 import 'package:current_results/src/result.dart' show Result;
 import 'package:current_results/src/slice.dart' show Slice;
+import 'package:test/test.dart';
 
 Slice makeTestSlice(Map<String, List<Map<String, dynamic>>> tests) {
   var slice = Slice();

--- a/current_results/test/iterable_test.dart
+++ b/current_results/test/iterable_test.dart
@@ -2,8 +2,8 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'package:test/test.dart';
 import 'package:current_results/src/iterable.dart';
+import 'package:test/test.dart';
 
 int intIdentity(int i) => i;
 

--- a/current_results/test/rest_api_test.dart
+++ b/current_results/test/rest_api_test.dart
@@ -1,3 +1,7 @@
+// Copyright (c) 2026, the Dart project authors.  Please see the AUTHORS file
+// for details. All rights reserved. Use of this source code is governed by a
+// BSD-style license that can be found in the LICENSE file.
+
 import 'dart:convert';
 import 'package:test/test.dart';
 import 'package:shelf/shelf.dart';

--- a/current_results/test/rest_api_test.dart
+++ b/current_results/test/rest_api_test.dart
@@ -1,0 +1,131 @@
+import 'dart:convert';
+import 'package:test/test.dart';
+import 'package:shelf/shelf.dart';
+import 'package:current_results/src/rest_api.dart';
+import 'package:current_results/src/slice.dart';
+import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/bucket.dart';
+import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart' show PubsubMessage;
+
+import 'package:mockito/annotations.dart';
+import 'rest_api_test.mocks.dart';
+import 'package:mockito/mockito.dart';
+
+@GenerateMocks([BucketNotifications, ResultsBucket])
+void main() {
+  group('RestApi tests', () {
+    late Slice slice;
+    late RestApi restApi;
+
+    setUp(() {
+      slice = Slice();
+      // Add fake results
+      slice.add([
+        jsonEncode({'name': 'test1', 'configuration': 'config_a', 'result': 'passed'}),
+        jsonEncode({'name': 'test2', 'configuration': 'config_a', 'result': 'failed'}),
+      ]);
+      slice.add([
+        jsonEncode({'name': 'test1', 'configuration': 'config_b', 'result': 'passed'}),
+      ]);
+      slice.collectTestNames();
+
+      final notifications = MockBucketNotifications();
+      when(notifications.initialize()).thenAnswer((_) async {});
+      when(notifications.getMessages()).thenAnswer((_) async => []);
+
+      final bucket = MockResultsBucket();
+      when(bucket.configurationDirectories()).thenAnswer((_) async => []);
+      when(bucket.latestResults(any)).thenAnswer((_) async => []);
+
+      restApi = RestApi(slice, notifications, bucket);
+    });
+
+    test('GET /v1/results - Returns all', () async {
+      final request = Request('GET', Uri.parse('http://localhost/v1/results'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      expect(response.headers['Content-Type'], 'application/json');
+
+      final body = jsonDecode(await response.readAsString());
+      expect(body['results'], isList);
+      expect(body['results'], hasLength(3));
+    });
+
+    test('GET /v1/results - With Filter', () async {
+      final request = Request(
+          'GET', Uri.parse('http://localhost/v1/results?filter=config_b'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['results'], hasLength(1));
+      expect(body['results'][0]['configuration'], 'config_b');
+    });
+
+    test('GET /v1/results - With PageSize', () async {
+      final request = Request(
+          'GET', Uri.parse('http://localhost/v1/results?page_size=1'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['results'], hasLength(1));
+      expect(body['nextPageToken'], isNotNull);
+    });
+
+    test('GET /v1/tests', () async {
+      final request = Request('GET', Uri.parse('http://localhost/v1/tests'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['names'], isList);
+      expect(body['names'], contains('test1'));
+      expect(body['names'], contains('test2'));
+    });
+
+    test('POST /v1/fetch', () async {
+      final notifications = MockBucketNotifications();
+      when(notifications.getMessages()).thenAnswer((_) async => [
+        PubsubMessage()
+          ..attributes.addAll({
+            'eventType': 'OBJECT_FINALIZE',
+            'objectId': 'configuration/main/config_c/latest'
+          })
+      ]);
+
+      final bucket = MockResultsBucket();
+      when(bucket.latestResults('configuration/main/config_c/')).thenAnswer((_) async => [
+        jsonEncode({'name': 'test3', 'configuration': 'config_c', 'result': 'passed'})
+      ]);
+
+      final apiWithFetch = RestApi(slice, notifications, bucket);
+
+      final request = Request('POST', Uri.parse('http://localhost/v1/fetch'));
+      final response = await apiWithFetch.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      final body = jsonDecode(await response.readAsString());
+      expect(body['updates'], isList);
+      expect(body['updates'][0]['configuration'], 'configuration/main/config_c/');
+
+      // Verify slice updated
+      expect(slice.size, 4); 
+    });
+
+    test('GET /v1/testPaths - Returns 501', () async {
+      final request = Request('GET', Uri.parse('http://localhost/v1/testPaths'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 501);
+    });
+
+    test('GET /invalid_path - Returns 404', () async {
+      final request = Request('GET', Uri.parse('http://localhost/invalid_path'));
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 404);
+    });
+  });
+}

--- a/current_results/test/rest_api_test.dart
+++ b/current_results/test/rest_api_test.dart
@@ -9,7 +9,8 @@ import 'package:current_results/src/rest_api.dart';
 import 'package:current_results/src/slice.dart';
 import 'package:current_results/src/notifications.dart';
 import 'package:current_results/src/bucket.dart';
-import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart' show PubsubMessage;
+import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
+    show PubsubMessage;
 
 import 'package:mockito/annotations.dart';
 import 'rest_api_test.mocks.dart';
@@ -25,11 +26,23 @@ void main() {
       slice = Slice();
       // Add fake results
       slice.add([
-        jsonEncode({'name': 'test1', 'configuration': 'config_a', 'result': 'passed'}),
-        jsonEncode({'name': 'test2', 'configuration': 'config_a', 'result': 'failed'}),
+        jsonEncode({
+          'name': 'test1',
+          'configuration': 'config_a',
+          'result': 'passed',
+        }),
+        jsonEncode({
+          'name': 'test2',
+          'configuration': 'config_a',
+          'result': 'failed',
+        }),
       ]);
       slice.add([
-        jsonEncode({'name': 'test1', 'configuration': 'config_b', 'result': 'passed'}),
+        jsonEncode({
+          'name': 'test1',
+          'configuration': 'config_b',
+          'result': 'passed',
+        }),
       ]);
       slice.collectTestNames();
 
@@ -58,7 +71,9 @@ void main() {
 
     test('GET /v1/results - With Filter', () async {
       final request = Request(
-          'GET', Uri.parse('http://localhost/v1/results?filter=config_b'));
+        'GET',
+        Uri.parse('http://localhost/v1/results?filter=config_b'),
+      );
       final response = await restApi.handleRequest(request);
 
       expect(response.statusCode, 200);
@@ -69,7 +84,9 @@ void main() {
 
     test('GET /v1/results - With PageSize', () async {
       final request = Request(
-          'GET', Uri.parse('http://localhost/v1/results?page_size=1'));
+        'GET',
+        Uri.parse('http://localhost/v1/results?page_size=1'),
+      );
       final response = await restApi.handleRequest(request);
 
       expect(response.statusCode, 200);
@@ -91,18 +108,26 @@ void main() {
 
     test('POST /v1/fetch', () async {
       final notifications = MockBucketNotifications();
-      when(notifications.getMessages()).thenAnswer((_) async => [
-        PubsubMessage()
-          ..attributes.addAll({
-            'eventType': 'OBJECT_FINALIZE',
-            'objectId': 'configuration/main/config_c/latest'
-          })
-      ]);
+      when(notifications.getMessages()).thenAnswer(
+        (_) async => [
+          PubsubMessage()
+            ..attributes.addAll({
+              'eventType': 'OBJECT_FINALIZE',
+              'objectId': 'configuration/main/config_c/latest',
+            }),
+        ],
+      );
 
       final bucket = MockResultsBucket();
-      when(bucket.latestResults('configuration/main/config_c/')).thenAnswer((_) async => [
-        jsonEncode({'name': 'test3', 'configuration': 'config_c', 'result': 'passed'})
-      ]);
+      when(bucket.latestResults('configuration/main/config_c/')).thenAnswer(
+        (_) async => [
+          jsonEncode({
+            'name': 'test3',
+            'configuration': 'config_c',
+            'result': 'passed',
+          }),
+        ],
+      );
 
       final apiWithFetch = RestApi(slice, notifications, bucket);
 
@@ -112,21 +137,30 @@ void main() {
       expect(response.statusCode, 200);
       final body = jsonDecode(await response.readAsString());
       expect(body['updates'], isList);
-      expect(body['updates'][0]['configuration'], 'configuration/main/config_c/');
+      expect(
+        body['updates'][0]['configuration'],
+        'configuration/main/config_c/',
+      );
 
       // Verify slice updated
-      expect(slice.size, 4); 
+      expect(slice.size, 4);
     });
 
     test('GET /v1/testPaths - Returns 501', () async {
-      final request = Request('GET', Uri.parse('http://localhost/v1/testPaths'));
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/v1/testPaths'),
+      );
       final response = await restApi.handleRequest(request);
 
       expect(response.statusCode, 501);
     });
 
     test('GET /invalid_path - Returns 404', () async {
-      final request = Request('GET', Uri.parse('http://localhost/invalid_path'));
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/invalid_path'),
+      );
       final response = await restApi.handleRequest(request);
 
       expect(response.statusCode, 404);

--- a/current_results/test/rest_api_test.dart
+++ b/current_results/test/rest_api_test.dart
@@ -3,18 +3,19 @@
 // BSD-style license that can be found in the LICENSE file.
 
 import 'dart:convert';
-import 'package:test/test.dart';
-import 'package:shelf/shelf.dart';
-import 'package:current_results/src/rest_api.dart';
-import 'package:current_results/src/slice.dart';
-import 'package:current_results/src/notifications.dart';
+
 import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
     show PubsubMessage;
-
+import 'package:current_results/src/notifications.dart';
+import 'package:current_results/src/rest_api.dart';
+import 'package:current_results/src/slice.dart';
 import 'package:mockito/annotations.dart';
-import 'rest_api_test.mocks.dart';
 import 'package:mockito/mockito.dart';
+import 'package:shelf/shelf.dart';
+import 'package:test/test.dart';
+
+import 'rest_api_test.mocks.dart';
 
 @GenerateMocks([BucketNotifications, ResultsBucket])
 void main() {

--- a/current_results/test/slice_test.dart
+++ b/current_results/test/slice_test.dart
@@ -4,8 +4,8 @@
 
 import 'package:current_results/src/generated/query.pbgrpc.dart' as query_api;
 import 'package:current_results/src/result.dart';
-import 'package:test/test.dart';
 import 'package:current_results/src/slice.dart';
+import 'package:test/test.dart';
 
 void main() {
   test('add results', () {


### PR DESCRIPTION
The current gRPC API is overkill and relies on an Envoy proxy. Envoy's images are falling behind on security updates. Removing Envoy from the architecture simplifies the production environment, increases security (the service is unauthenticated and read-only and has minimal dependencies). This REST API will replace the gRPC API when the client has been migrated.