### PR TITLE
[current-results][current-results-ui] Use protobuf binary format

### DIFF
--- a/current_results/lib/src/api_impl.dart
+++ b/current_results/lib/src/api_impl.dart
@@ -8,6 +8,7 @@ import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/generated/query.pb.dart';
 import 'package:current_results/src/notifications.dart';
 import 'package:current_results/src/slice.dart';
+import 'package:protobuf/protobuf.dart';
 import 'package:shelf/shelf.dart';
 import 'package:shelf_router/shelf_router.dart';
 
@@ -36,7 +37,8 @@ class RestApi {
   }
 
   @Route.options('/<ignored|.*>')
-  Future<Response> _options(Request request) async => Response.ok('');
+  Future<Response> _options(Request request) async =>
+      Response.ok('', headers: _corsHeaders);
 
   @Route.get('/v1/testPaths')
   Future<Response> _testPaths(Request request) async =>
@@ -60,10 +62,7 @@ class RestApi {
       protoRequest.pageToken = pageToken;
     }
     final response = current.results(protoRequest);
-    return Response.ok(
-      jsonEncode(response.toProto3Json()),
-      headers: {'Content-Type': 'application/json'},
-    );
+    return _respond(request, response);
   }
 
   @Route.get('/v1/tests')
@@ -77,18 +76,29 @@ class RestApi {
       protoRequest.limit = int.tryParse(limit) ?? 0;
     }
     final response = current.listTests(protoRequest);
-    return Response.ok(
-      jsonEncode(response.toProto3Json()),
-      headers: {'Content-Type': 'application/json'},
-    );
+    return _respond(request, response);
   }
 
   @Route.post('/v1/fetch')
   Future<Response> _fetch(Request request) async {
     final response = await fetchUpdates(notifications, bucket, current);
+    return _respond(request, response);
+  }
+
+  Response _respond(Request request, GeneratedMessage response) {
+    final accept = request.headers['Accept'] ?? '';
+    final Object body;
+    final String contentType;
+    if (accept.contains('application/x-protobuf')) {
+      body = response.writeToBuffer();
+      contentType = 'application/x-protobuf';
+    } else {
+      body = jsonEncode(response.toProto3Json());
+      contentType = 'application/json';
+    }
     return Response.ok(
-      jsonEncode(response.toProto3Json()),
-      headers: {'Content-Type': 'application/json'},
+      body,
+      headers: {'Content-Type': contentType, ..._corsHeaders},
     );
   }
 }

--- a/current_results/test/rest_api_test.dart
+++ b/current_results/test/rest_api_test.dart
@@ -8,6 +8,7 @@ import 'package:current_results/src/api_impl.dart';
 import 'package:current_results/src/bucket.dart';
 import 'package:current_results/src/generated/google/pubsub/v1/pubsub.pbgrpc.dart'
     show PubsubMessage;
+import 'package:current_results/src/generated/query.pb.dart';
 import 'package:current_results/src/notifications.dart';
 import 'package:current_results/src/slice.dart';
 import 'package:mockito/annotations.dart';
@@ -70,6 +71,22 @@ void main() {
       expect(body['results'], hasLength(3));
     });
 
+    test('GET /v1/results - Returns Binary Protobuf', () async {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/v1/results'),
+        headers: {'Accept': 'application/x-protobuf'},
+      );
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      expect(response.headers['Content-Type'], 'application/x-protobuf');
+
+      final bytes = await response.read().expand((b) => b).toList();
+      final body = GetResultsResponse.fromBuffer(bytes);
+      expect(body.results, hasLength(3));
+    });
+
     test('GET /v1/results - With Filter', () async {
       final request = Request(
         'GET',
@@ -105,6 +122,23 @@ void main() {
       expect(body['names'], isList);
       expect(body['names'], contains('test1'));
       expect(body['names'], contains('test2'));
+    });
+
+    test('GET /v1/tests - Returns Binary Protobuf', () async {
+      final request = Request(
+        'GET',
+        Uri.parse('http://localhost/v1/tests'),
+        headers: {'Accept': 'application/x-protobuf'},
+      );
+      final response = await restApi.handleRequest(request);
+
+      expect(response.statusCode, 200);
+      expect(response.headers['Content-Type'], 'application/x-protobuf');
+
+      final bytes = await response.read().expand((b) => b).toList();
+      final body = ListTestsResponse.fromBuffer(bytes);
+      expect(body.names, contains('test1'));
+      expect(body.names, contains('test2'));
     });
 
     test('POST /v1/fetch', () async {

--- a/current_results_ui/lib/src/features/results_overview/data/results_repository.dart
+++ b/current_results_ui/lib/src/features/results_overview/data/results_repository.dart
@@ -4,7 +4,6 @@
 
 import 'dart:async';
 import 'dart:collection';
-import 'dart:convert';
 
 import 'package:flutter/foundation.dart';
 import 'package:http/http.dart' as http;

--- a/current_results_ui/lib/src/features/results_overview/data/results_repository.dart
+++ b/current_results_ui/lib/src/features/results_overview/data/results_repository.dart
@@ -129,9 +129,11 @@ class QueryResults extends QueryResultsBase {
         'pageSize': '$fetchLimit',
         'pageToken': pageToken,
       });
-      final response = await _client.get(resultsQuery);
-      final results = GetResultsResponse.create()
-        ..mergeFromProto3Json(json.decode(response.body));
+      final response = await _client.get(
+        resultsQuery,
+        headers: {'Accept': 'application/x-protobuf'},
+      );
+      final results = GetResultsResponse.fromBuffer(response.bodyBytes);
       yield results;
       pageToken = results.nextPageToken;
     } while (pageToken.isNotEmpty);

--- a/current_results_ui/test/query_test.dart
+++ b/current_results_ui/test/query_test.dart
@@ -2,8 +2,6 @@
 // for details. All rights reserved. Use of this source code is governed by a
 // BSD-style license that can be found in the LICENSE file.
 
-import 'dart:convert';
-
 import 'package:flutter_current_results/src/data/models/filter.dart';
 import 'package:flutter_current_results/src/features/results_overview/data/results_repository.dart';
 import 'package:flutter_current_results/src/shared/generated/query.pb.dart';
@@ -175,13 +173,17 @@ void main() {
         ],
         nextPageToken: '',
       );
-      when(mockClient.get(any)).thenAnswer(
-        (_) async => http.Response(jsonEncode(response.toProto3Json()), 200),
+      when(mockClient.get(any, headers: anyNamed('headers'))).thenAnswer(
+        (_) async => http.Response.bytes(
+          response.writeToBuffer(),
+          200,
+          headers: {'content-type': 'application/x-protobuf'},
+        ),
       );
 
       queryResults.filter = Filter('test');
 
-      await untilCalled(mockClient.get(any));
+      await untilCalled(mockClient.get(any, headers: anyNamed('headers')));
       while (!queryResults.isDone) {
         await Future.delayed(Duration.zero);
       }


### PR DESCRIPTION
Reduces the data transferred over the wire from 70MB to 40MB for the worst case response. Load time didn't decrease for me running the client locally (but may be faster when running in release mode with WASM).