### PR TITLE
Authenticate gerritcodereview log requests.

### DIFF
--- a/builder/bin/upload_results_to_database.dart
+++ b/builder/bin/upload_results_to_database.dart
@@ -83,7 +83,10 @@ void main(List<String> arguments) async {
 
   final baseClient = http.Client();
   final client = await clientViaApplicationDefaultCredentials(
-    scopes: ['https://www.googleapis.com/auth/cloud-platform'],
+    scopes: [
+      'https://www.googleapis.com/auth/cloud-platform',
+      'https://www.googleapis.com/auth/gerritcodereview',
+    ],
     baseClient: baseClient,
   );
   final api = FirestoreApi(client);

--- a/builder/lib/src/commits_cache.dart
+++ b/builder/lib/src/commits_cache.dart
@@ -70,7 +70,7 @@ class CommitsCache {
     final lastIndex = lastCommit.index;
 
     final branch = 'main';
-    final logUrl = 'https://dart.googlesource.com/sdk/+log/';
+    final logUrl = 'https://dart.googlesource.com/a/sdk/+log/';
     final range = '$lastHash..$branch';
     final parameters = ['format=JSON', 'topo-order', 'first-parent', 'n=1000'];
     final url = Uri.parse('$logUrl$range?${parameters.join('&')}');


### PR DESCRIPTION
This is to avoid DDOS rule applied to the requests. Example of failing builds https://ci.chromium.org/ui/p/dart/builders/ci.sandbox/vm-linux-debug-x64/7314/overview
