### PR TITLE
Use custom service account for github-label-notifier

### DIFF
--- a/github-label-notifier/cloudbuild.yaml
+++ b/github-label-notifier/cloudbuild.yaml
@@ -5,4 +5,13 @@ steps:
   args: ['push', 'gcr.io/dart-ci/github-label-notifier']
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
-  args: ['run', 'deploy', 'github-webhook', '--image', 'gcr.io/dart-ci/github-label-notifier', '--region', 'us-central1', '--service-account', 'github-label-notifier@dart-ci.iam.gserviceaccount.com']
+  args:
+  - 'run'
+  - 'deploy'
+  - 'github-webhook'
+  - '--image'
+  - 'gcr.io/dart-ci/github-label-notifier'
+  - '--region'
+  - 'us-central1'
+  - '--service-account'
+  - 'github-label-notifier@dart-ci.iam.gserviceaccount.com'

--- a/github-label-notifier/cloudbuild.yaml
+++ b/github-label-notifier/cloudbuild.yaml
@@ -5,4 +5,4 @@ steps:
   args: ['push', 'gcr.io/dart-ci/github-label-notifier']
 - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
   entrypoint: gcloud
-  args: ['run', 'deploy', 'github-webhook', '--image', 'gcr.io/dart-ci/github-label-notifier', '--region', 'us-central1']
+  args: ['run', 'deploy', 'github-webhook', '--image', 'gcr.io/dart-ci/github-label-notifier', '--region', 'us-central1', '--service-account', 'github-label-notifier@dart-ci.iam.gserviceaccount.com']

--- a/github-label-notifier/functions/deploy.sh
+++ b/github-label-notifier/functions/deploy.sh
@@ -21,4 +21,5 @@ gcloud run deploy github-webhook --port 8080 --project dart-ci \
     --memory 128Mi \
     --source=./ --allow-unauthenticated \
     --description 'The Github label notifier service' \
-    --set-env-vars "GITHUB_SECRET=$GITHUB_SECRET,SENDGRID_SECRET=$SENDGRID_SECRET"
+    --set-env-vars "GITHUB_SECRET=$GITHUB_SECRET,SENDGRID_SECRET=$SENDGRID_SECRET" \
+    --service-account github-label-notifier@dart-ci.iam.gserviceaccount.com


### PR DESCRIPTION
This PR updates the deployment configuration to use a custom service account instead of the default compute engine service account.