### PR TITLE
Migrate baseline builder from gsutil to google_cloud_storage

### DIFF
--- a/baseline/dart_test.yaml
+++ b/baseline/dart_test.yaml
@@ -1,2 +1,0 @@
-tags:
-  requires_gsutil: {}

--- a/baseline/lib/baseline.dart
+++ b/baseline/lib/baseline.dart
@@ -7,21 +7,26 @@ import 'dart:convert';
 import 'dart:io';
 
 import 'package:pool/pool.dart';
+import 'package:google_cloud_storage/google_cloud_storage.dart';
 
 const _resultBase = 'gs://dart-test-results';
 
 /// Baselines a builder with the [options] and copies the results to the
-/// [resultBase]. [resultBase] can be a URL or a path supported by `gsutil cp`.
+/// [resultBase]. [resultBase] can be a GCS URL (gs://...) or a local path.
 Future<void> baseline(
   BaselineOptions options, [
   String resultBase = _resultBase,
 ]) async {
+  final FileStore store = resultBase.startsWith('gs://')
+      ? GcsFileStore(Storage())
+      : LocalFileStore();
   await Future.wait([
     for (final channel in options.channels)
       if (channel == 'main')
         // baseline a new builder on main
         // builder,builder2 -> new-builder
         baselineBuilder(
+          store,
           options.builders,
           channel,
           options.suites,
@@ -35,6 +40,7 @@ Future<void> baseline(
         // baseline a builder on a channel with main builder data
         // builder,builder2 -> builder-dev
         baselineBuilder(
+          store,
           options.builders,
           channel,
           options.suites,
@@ -48,6 +54,7 @@ Future<void> baseline(
         // baseline a builder on a channel with channel builder data
         // builder-dev,builder2-dev -> new-builder-dev
         baselineBuilder(
+          store,
           options.builders.map((b) => '$b-$channel').toList(),
           channel,
           options.suites,
@@ -61,6 +68,7 @@ Future<void> baseline(
 }
 
 Future<void> baselineBuilder(
+  FileStore store,
   List<String> builders,
   String channel,
   Set<String> suites,
@@ -71,8 +79,10 @@ Future<void> baselineBuilder(
   String resultBase,
 ) async {
   var resultsStream = Pool(4).forEach(builders, (builder) async {
-    var latest = await read('$resultBase/builders/$builder/latest');
-    return await read('$resultBase/builders/$builder/$latest/results.json');
+    var latest = await store.read('$resultBase/builders/$builder/latest');
+    return await store.read(
+      '$resultBase/builders/$builder/$latest/results.json',
+    );
   });
   var modifiedResults = StringBuffer();
   var modifiedResultsPerConfig = <String, StringBuffer>{};
@@ -102,27 +112,75 @@ Future<void> baselineBuilder(
       if (dryRun) break;
     }
   }
-  await write(
+  await store.write(
     '$resultBase/builders/$target/0/results.json',
     modifiedResults.toString(),
     dryRun,
   );
   for (var entry in modifiedResultsPerConfig.entries) {
-    await write(
+    await store.write(
       '$resultBase/configuration/$channel/${entry.key}/0/results.json',
       entry.value.toString(),
       dryRun,
     );
   }
-  await write('$resultBase/builders/$target/latest', '0', dryRun);
+  await store.write('$resultBase/builders/$target/latest', '0', dryRun);
 }
 
-Future<String> read(String url) {
-  return run('gsutil', ['cp', url, '-']);
+abstract class FileStore {
+  Future<String> read(String path);
+  Future<void> write(String path, String content, bool dryRun);
 }
 
-Future<String> write(String url, String stdin, bool dryRun) {
-  return run('gsutil', ['cp', '-', url], stdin: stdin, dryRun: dryRun);
+class GcsFileStore implements FileStore {
+  final Storage _storage;
+  GcsFileStore(this._storage);
+
+  (String, String) _parseGsUrl(String url) {
+    final uri = Uri.parse(url);
+    if (uri.scheme != 'gs') {
+      throw ArgumentError('Invalid scheme: ${uri.scheme}, expected gs://');
+    }
+    final object = uri.path.startsWith('/') ? uri.path.substring(1) : uri.path;
+    return (uri.host, object);
+  }
+
+  @override
+  Future<String> read(String path) async {
+    final (bucket, object) = _parseGsUrl(path);
+    final bytes = await _storage.bucket(bucket).object(object).download();
+    return utf8.decode(bytes);
+  }
+
+  @override
+  Future<void> write(String path, String content, bool dryRun) async {
+    print('Writing to $path...');
+    if (dryRun) {
+      print('stdin:\n$content');
+      return;
+    }
+    final (bucket, object) = _parseGsUrl(path);
+    await _storage.bucket(bucket).object(object).uploadAsString(content);
+  }
+}
+
+class LocalFileStore implements FileStore {
+  @override
+  Future<String> read(String path) {
+    return File(path).readAsString();
+  }
+
+  @override
+  Future<void> write(String path, String content, bool dryRun) async {
+    print('Writing to $path...');
+    if (dryRun) {
+      print('stdin:\n$content');
+      return;
+    }
+    final file = File(path);
+    await file.parent.create(recursive: true);
+    await file.writeAsString(content);
+  }
 }
 
 Future<String> run(

--- a/baseline/lib/baseline.dart
+++ b/baseline/lib/baseline.dart
@@ -9,24 +9,19 @@ import 'dart:io';
 import 'package:pool/pool.dart';
 import 'package:google_cloud_storage/google_cloud_storage.dart';
 
-const _resultBase = 'gs://dart-test-results';
+const _defaultBucket = 'dart-test-results';
 
 /// Baselines a builder with the [options] and copies the results to the
-/// [resultBase]. [resultBase] can be a GCS URL (gs://...) or a local path.
-Future<void> baseline(
-  BaselineOptions options, [
-  String resultBase = _resultBase,
-]) async {
-  final FileStore store = resultBase.startsWith('gs://')
-      ? GcsFileStore(Storage())
-      : LocalFileStore();
+/// GCS [store] (defaults to GCS bucket 'dart-test-results').
+Future<void> baseline(BaselineOptions options, {FileStore? store}) async {
+  final FileStore fileStore = store ?? GcsFileStore(Storage(), _defaultBucket);
   await Future.wait([
     for (final channel in options.channels)
       if (channel == 'main')
         // baseline a new builder on main
         // builder,builder2 -> new-builder
         baselineBuilder(
-          store,
+          fileStore,
           options.builders,
           channel,
           options.suites,
@@ -34,13 +29,12 @@ Future<void> baseline(
           options.configs,
           options.dryRun,
           options.mapping,
-          resultBase,
         )
       else if (options.builders.contains(options.target))
         // baseline a builder on a channel with main builder data
         // builder,builder2 -> builder-dev
         baselineBuilder(
-          store,
+          fileStore,
           options.builders,
           channel,
           options.suites,
@@ -48,13 +42,12 @@ Future<void> baseline(
           options.configs,
           options.dryRun,
           options.mapping,
-          resultBase,
         )
       else
         // baseline a builder on a channel with channel builder data
         // builder-dev,builder2-dev -> new-builder-dev
         baselineBuilder(
-          store,
+          fileStore,
           options.builders.map((b) => '$b-$channel').toList(),
           channel,
           options.suites,
@@ -62,7 +55,6 @@ Future<void> baseline(
           options.configs,
           options.dryRun,
           options.mapping,
-          resultBase,
         ),
   ]);
 }
@@ -76,13 +68,10 @@ Future<void> baselineBuilder(
   Map<String, List<String>> configs,
   bool dryRun,
   ConfigurationMapping mapping,
-  String resultBase,
 ) async {
   var resultsStream = Pool(4).forEach(builders, (builder) async {
-    var latest = await store.read('$resultBase/builders/$builder/latest');
-    return await store.read(
-      '$resultBase/builders/$builder/$latest/results.json',
-    );
+    var latest = await store.read('builders/$builder/latest');
+    return await store.read('builders/$builder/$latest/results.json');
   });
   var modifiedResults = StringBuffer();
   var modifiedResultsPerConfig = <String, StringBuffer>{};
@@ -113,18 +102,18 @@ Future<void> baselineBuilder(
     }
   }
   await store.write(
-    '$resultBase/builders/$target/0/results.json',
+    'builders/$target/0/results.json',
     modifiedResults.toString(),
     dryRun,
   );
   for (var entry in modifiedResultsPerConfig.entries) {
     await store.write(
-      '$resultBase/configuration/$channel/${entry.key}/0/results.json',
+      'configuration/$channel/${entry.key}/0/results.json',
       entry.value.toString(),
       dryRun,
     );
   }
-  await store.write('$resultBase/builders/$target/latest', '0', dryRun);
+  await store.write('builders/$target/latest', '0', dryRun);
 }
 
 abstract class FileStore {
@@ -134,50 +123,49 @@ abstract class FileStore {
 
 class GcsFileStore implements FileStore {
   final Storage _storage;
-  GcsFileStore(this._storage);
+  final String _bucketName;
 
-  (String, String) _parseGsUrl(String url) {
-    final uri = Uri.parse(url);
-    if (uri.scheme != 'gs') {
-      throw ArgumentError('Invalid scheme: ${uri.scheme}, expected gs://');
-    }
-    final object = uri.path.startsWith('/') ? uri.path.substring(1) : uri.path;
-    return (uri.host, object);
-  }
+  GcsFileStore(this._storage, this._bucketName);
 
   @override
   Future<String> read(String path) async {
-    final (bucket, object) = _parseGsUrl(path);
-    final bytes = await _storage.bucket(bucket).object(object).download();
+    final bytes = await _storage.downloadObject(_bucketName, path);
     return utf8.decode(bytes);
   }
 
   @override
   Future<void> write(String path, String content, bool dryRun) async {
-    print('Writing to $path...');
+    print('Writing to gs://$_bucketName/$path...');
     if (dryRun) {
       print('stdin:\n$content');
       return;
     }
-    final (bucket, object) = _parseGsUrl(path);
-    await _storage.bucket(bucket).object(object).uploadAsString(content);
+    await _storage.uploadObjectFromString(_bucketName, path, content);
   }
 }
 
 class LocalFileStore implements FileStore {
+  final String _baseDir;
+  LocalFileStore(this._baseDir);
+
+  String _getPath(String relativePath) {
+    return '$_baseDir/$relativePath';
+  }
+
   @override
   Future<String> read(String path) {
-    return File(path).readAsString();
+    return File(_getPath(path)).readAsString();
   }
 
   @override
   Future<void> write(String path, String content, bool dryRun) async {
-    print('Writing to $path...');
+    final fullPath = _getPath(path);
+    print('Writing to $fullPath...');
     if (dryRun) {
       print('stdin:\n$content');
       return;
     }
-    final file = File(path);
+    final file = File(fullPath);
     await file.parent.create(recursive: true);
     await file.writeAsString(content);
   }

--- a/baseline/pubspec.lock
+++ b/baseline/pubspec.lock
@@ -49,6 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  clock:
+    dependency: transitive
+    description:
+      name: clock
+      sha256: fddb70d9b5277016c77a80201021d40a2247104d9f4aa7bab7157b7e3f05b84b
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
   collection:
     dependency: transitive
     description:
@@ -81,6 +89,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.7"
+  ffi:
+    dependency: transitive
+    description:
+      name: ffi
+      sha256: "6d7fd89431262d8f3125e81b50d3847a091d846eafcd4fdb88dd06f36d705a45"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.2.0"
   file:
     dependency: transitive
     description:
@@ -105,6 +121,62 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_cloud:
+    dependency: transitive
+    description:
+      name: google_cloud
+      sha256: b385e20726ef5315d302c5933bfb728103116c5be2d3d17094b01a82da538c1f
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.0"
+  google_cloud_protobuf:
+    dependency: transitive
+    description:
+      name: google_cloud_protobuf
+      sha256: f45f656c63d040b21d5cf947a3c44d537eb82ee68e485ccfcf2edbcbd1041461
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
+  google_cloud_rpc:
+    dependency: transitive
+    description:
+      name: google_cloud_rpc
+      sha256: "143ca2179dbcc5e4d16e8ee352aa4891b105b0aafc4e617bd4d713715a4afef2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.2"
+  google_cloud_storage:
+    dependency: "direct main"
+    description:
+      name: google_cloud_storage
+      sha256: cb4f2887e445c51c33de6de3275948037cdf15080e4d8725f1c6dfc0a88b38de
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.6.2"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  googleapis_auth:
+    dependency: transitive
+    description:
+      name: googleapis_auth
+      sha256: "2a8895c3885197f96bb2fd91ee0ae77b53ff3874c7b1f1eadb6566248e880958"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.3.1"
+  http:
+    dependency: transitive
+    description:
+      name: http
+      sha256: "87721a4a50b19c7f1d49001e51409bddc46303966ce89a65af4f4e6004896412"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   http_multi_server:
     dependency: transitive
     description:

--- a/baseline/pubspec.yaml
+++ b/baseline/pubspec.yaml
@@ -9,6 +9,8 @@ environment:
 dependencies:
   args: ^2.3.0
   pool: ^1.5.0
+  google_cloud_storage: ^0.6.2
+
 
 dev_dependencies:
   io: ^1.0.3

--- a/baseline/test/baseline_test.dart
+++ b/baseline/test/baseline_test.dart
@@ -82,7 +82,7 @@ void main() {
       '--dry-run',
       '--ignore-unmapped',
     ], testData);
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline ignored config mapping', () async {
     final newBuilderStableResults = [
@@ -110,7 +110,7 @@ void main() {
         ...testData,
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline default config mapping', () async {
     final newBuilderDevResults = [
@@ -159,7 +159,7 @@ void main() {
         'configuration/dev/config4/0/results.json': [newBuilderDevResults[3]],
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline dry-run', () async {
     await baselineTest([
@@ -170,7 +170,7 @@ void main() {
           'config3:new-config3,config4:new-config4',
       '--dry-run',
     ], testData);
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline', () async {
     final newBuilderStableResults = [
@@ -222,7 +222,7 @@ void main() {
         ...testData,
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline with suite filter', () async {
     final newBuilderStableResults = [
@@ -262,7 +262,7 @@ void main() {
         ...testData,
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline merge configs', () async {
     final newBuilderStableResults = [
@@ -300,7 +300,7 @@ void main() {
         ...testData,
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 
   test('baseline split configs', () async {
     final newBuilderStableResults = [
@@ -339,7 +339,7 @@ void main() {
         ...testData,
       },
     );
-  }, tags: ['requires_gsutil']);
+  });
 }
 
 Future<void> baselineTest(

--- a/baseline/test/baseline_test.dart
+++ b/baseline/test/baseline_test.dart
@@ -67,7 +67,7 @@ void main() {
           '--config-mapping=config2:new-config2',
           '--dry-run',
         ]),
-        'test/data',
+        store: LocalFileStore('test/data'),
       ),
       throwsException,
     );
@@ -349,7 +349,10 @@ Future<void> baselineTest(
   var temp = await Directory.systemTemp.createTemp();
   try {
     await copyPath('test/data', temp.path);
-    await baseline(BaselineOptions.parse(arguments), temp.path);
+    await baseline(
+      BaselineOptions.parse(arguments),
+      store: LocalFileStore(temp.path),
+    );
     var files = temp
         .listSync(recursive: true)
         .whereType<File>()


### PR DESCRIPTION
- Replace gsutil process calls with google_cloud_storage package.

- Introduce FileStore abstraction with GcsFileStore and LocalFileStore.

- Use LocalFileStore as a fallback when resultBase is a local path.

- Remove requires_gsutil tags from tests as they now run locally without gsutil.
